### PR TITLE
Set data correctly in fields that wrap around the end-of-screen.

### DIFF
--- a/openterm/src/main/java/com/ascert/open/term/core/AbstractTerminal.java
+++ b/openterm/src/main/java/com/ascert/open/term/core/AbstractTerminal.java
@@ -1005,7 +1005,7 @@ public abstract class AbstractTerminal
                     if (autoFieldWrap)
                     {
                         TermField firstField = fields.elementAt(0);
-                        lastField.setEndBA((firstField.getBeginBA() == 0) ? chars.length
+                        lastField.setEndBA((firstField.getBeginBA() == 0) ? chars.length - 1
                             : firstField.getBeginBA() - 1);
 
                         for (int cx = 0; cx < firstField.getBeginBA(); cx++)


### PR DESCRIPTION
Correctly set last field end buffer address when it's at the end-of-screen.