### PR TITLE
Fix unformatted buffer handling

### DIFF
--- a/openterm/src/main/java/com/ascert/open/term/i3270/Tn3270StreamParser.java
+++ b/openterm/src/main/java/com/ascert/open/term/i3270/Tn3270StreamParser.java
@@ -986,7 +986,7 @@ public class Tn3270StreamParser implements TnStreamParser
             {
                 Term3270Char currChar = chars[i];
 
-                if (currChar.getChar() != ' ')
+                if (currChar.getChar() != 0) //null suppression
                 {
                     dataOut[byteCount++] = (short) asc2ebc[currChar.getChar()];
                 }


### PR DESCRIPTION
Suppress null, not space, when sending, and allow typing on the unformatted screen in the GUI.

Also clean up backspace and delete handlers to write null rather than
space for the deleted char, and not throw unnecessary protected exceptions.