### PR TITLE
Fix unformatted buffer handling for 3270

### DIFF
--- a/openterm/src/main/java/com/ascert/open/term/core/Terminal.java
+++ b/openterm/src/main/java/com/ascert/open/term/core/Terminal.java
@@ -353,7 +353,17 @@ public interface Terminal
     {
         return null;
     }
-    
+
+    default boolean allowDirectScreenEditing()
+    {
+        return false;
+    }
+
+    default char getEmptyChar()
+    {
+        return ' ';
+    }
+
     /**
      * @return the host
      */

--- a/openterm/src/main/java/com/ascert/open/term/gui/AbstractKeyHandler.java
+++ b/openterm/src/main/java/com/ascert/open/term/gui/AbstractKeyHandler.java
@@ -277,9 +277,13 @@ public abstract class AbstractKeyHandler implements KeyHandler
                     }
                     evt.consume();
                 }
+                catch (IsProtectedException e)
+                {
+                    log.warning(e.toString());
+                }
                 catch (Exception e)
                 {
-                    log.warning(e.getMessage());
+                    log.log(Level.WARNING, "Error in char handler", e);
                 }
             }
             else
@@ -311,31 +315,52 @@ public abstract class AbstractKeyHandler implements KeyHandler
             }
 
             int oldPos = term.getCursorPosition();
-            TermField f = term.getField(oldPos);
+            int newPos = oldPos + 1;
             TermChar ch = term.getChar(oldPos);
 
-            if (ch.isStartField() || f == null || f.isProtected())
+            if (term.allowDirectScreenEditing())
             {
-                throw new IsProtectedException();
+                ch.setChar(key);
+                term.setCursorPosition(newPos);
             }
-
-            if (!f.isValidInput(key))
+            else
             {
-                term.getClient().beep();
-                return false;
+                TermField f = term.getField(oldPos);
+
+                if (ch.isStartField() || f == null || f.isProtected())
+                {
+                    throw new IsProtectedException();
+                }
+
+                if (!f.isValidInput(key))
+                {
+                    term.getClient().beep();
+                    return false;
+                }
+
+                ch.setChar(f.applyTransform(key));
+                f.setModified(true);
+
+                int bufsize = term.getCharBuffer().length;
+                if (f.getEndBA() < f.getBeginBA() && newPos >= bufsize)
+                {
+                    newPos -= bufsize;
+                }
+                if (newPos > f.getEndBA())
+                {
+                    if (f.isAutoTab())
+                    {
+                        term.setCursorPosition(term.getNextUnprotectedField(newPos));
+                    }
+                    else
+                    {
+                        term.getClient().beep();
+                    }
+                    return true;
+                }
+
+                term.setCursorPosition(newPos);
             }
-
-            ch.setChar(f.applyTransform(key));
-            f.setModified(true);
-
-            int newPos = oldPos + 1;
-            if (newPos > f.getEndBA() && !f.isAutoTab())
-            {
-                term.getClient().beep();
-                return true;
-            }
-
-            term.setCursorPosition(newPos);
             return true;
         }
 
@@ -519,9 +544,9 @@ public abstract class AbstractKeyHandler implements KeyHandler
     }
 
     /**
-     * Deletes the current character (by setting it to ' ') and decrements the cursor position by one.
+     * Deletes the current character (by setting it to empty) and decrements the cursor position by one.
      *
-     * @throws IsProtectedException if the backspace will go into a protected field
+     * @throws IsProtectedException if the current field is protected.
      */
     public class BackspaceAction extends KeyAction
     {
@@ -529,21 +554,67 @@ public abstract class AbstractKeyHandler implements KeyHandler
         public boolean handle() throws IsProtectedException
         {
             int newPos = term.getCursorPosition() - 1;
-            TermChar ch = term.getChar(newPos);
-            if (ch.getField().isProtected() || ch.isStartField())
+            int bufsize = term.getCharBuffer().length;
+            int len;
+            if (term.allowDirectScreenEditing())
             {
-                throw new IsProtectedException();
+                if (newPos < 0)
+                {
+                    return true;
+                }
+                len = bufsize - 1 - newPos;
             }
-
+            else
+            {
+                if (newPos < 0)
+                {
+                    if (term.getChar(0).getField() == term.getChar(newPos + bufsize).getField())
+                    {
+                        newPos += bufsize;
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
+                TermChar ch = term.getChar(newPos);
+                TermField fld = ch.getField();
+                if (fld == null || fld.isProtected())
+                {
+                    throw new IsProtectedException();
+                }
+                if (ch.isStartField())
+                {
+                    return true;
+                }
+                fld.setModified(true);
+                len = fld.getEndBA() - newPos;
+                // Must allow for possible field wrapping
+                if (len < 0)
+                {
+                    len += bufsize;
+                }
+            }
+            //TODO - wonder if we should use clear to reset any video attributes??
+            int pos = newPos;
+            for (int ix = 0; ix < len; ix++)
+            {
+                int nextpos = pos + 1;
+                if (nextpos >= bufsize)
+                {
+                    nextpos = 0;
+                }
+                term.getChar(pos).setChar(term.getChar(nextpos).getChar());
+                pos = nextpos;
+            }
+            term.getChar(pos).setChar(term.getEmptyChar());
             term.setCursorPosition(newPos);
-            ch.getField().setModified(true);
-            ch.setChar(' ');    //TODO - wonder if we should use clear to reset any video attributes??
             return true;
         }
     }
 
     /**
-     * Deletes the current character (by setting it to ' ').
+     * Deletes the current character (by setting it to empty).
      *
      * @throws IsProtectedException if the current field is protected.
      */
@@ -553,20 +624,39 @@ public abstract class AbstractKeyHandler implements KeyHandler
         public boolean handle() throws IsProtectedException
         {
             int pos = term.getCursorPosition();
-            TermField fld = term.getChar(pos).getField();
-            if (fld.isProtected())
+            int bufsize = term.getCharBuffer().length;
+            int len;
+            if (term.allowDirectScreenEditing())
             {
-                throw new IsProtectedException();
+                len = bufsize - 1 - pos;
             }
-
-            for (int ix = pos; ix < fld.getEndBA(); ix++)
+            else
             {
-                term.getChar(ix).setChar(term.getChar(ix + 1).getChar());
+                TermChar ch = term.getChar(pos);
+                TermField fld = ch.getField();
+                if (fld == null || fld.isProtected() || ch.isStartField())
+                {
+                    throw new IsProtectedException();
+                }
+                fld.setModified(true);
+                len = fld.getEndBA() - pos;
+                // Must allow for possible field wrapping
+                if (len < 0)
+                {
+                    len += bufsize;
+                }
             }
-
-            TermChar ch = term.getChar(fld.getEndBA());
-            ch.setChar(' ');
-            ch.getField().setModified(true);
+            for (int ix = 0; ix < len; ix++)
+            {
+                int nextpos = pos + 1;
+                if (nextpos >= bufsize)
+                {
+                    nextpos = 0;
+                }
+                term.getChar(pos).setChar(term.getChar(nextpos).getChar());
+                pos = nextpos;
+            }
+            term.getChar(pos).setChar(term.getEmptyChar());
             return true;
         }
     }

--- a/openterm/src/main/java/com/ascert/open/term/i3270/Term3270.java
+++ b/openterm/src/main/java/com/ascert/open/term/i3270/Term3270.java
@@ -197,6 +197,18 @@ public class Term3270
     }
 
     @Override
+    public boolean allowDirectScreenEditing()
+    {
+        return getFields().size() == 0;
+    }
+
+    @Override
+    public char getEmptyChar()
+    {
+        return 0;
+    }
+
+    @Override
     public void Fkey(OHIO_AID key)
     {
         super.Fkey(key);

--- a/openterm/src/main/java/com/ascert/open/term/i3270/Tn3270StreamParser.java
+++ b/openterm/src/main/java/com/ascert/open/term/i3270/Tn3270StreamParser.java
@@ -986,7 +986,7 @@ public class Tn3270StreamParser implements TnStreamParser
             {
                 Term3270Char currChar = chars[i];
 
-                if (currChar.getChar() != ' ')
+                if (currChar.getChar() != 0) //null suppression
                 {
                     dataOut[byteCount++] = (short) asc2ebc[currChar.getChar()];
                 }


### PR DESCRIPTION
Suppress null, not space, when sending; and allow typing on the unformatted screen in the GUI.

Also clean up backspace and delete handlers not to throw unnecessary
protected exceptions, and write null rather than space for the deleted
char in 3270.

Ensure editing in wrapped fields works correctly.